### PR TITLE
Add @rpath, @loader_path and @executable_path to the libraries rpaths

### DIFF
--- a/libIntegra/xcode/Integra/Integra.xcodeproj/project.pbxproj
+++ b/libIntegra/xcode/Integra/Integra.xcodeproj/project.pbxproj
@@ -1255,6 +1255,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1273,6 +1274,8 @@
 					../../externals/boost,
 				);
 				INFOPLIST_FILE = "Integra/Integra-Info.plist";
+				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"../../externals/macosx/fftw-3.3.3",
@@ -1313,6 +1316,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1330,6 +1334,8 @@
 					../../externals/boost,
 				);
 				INFOPLIST_FILE = "Integra/Integra-Info.plist";
+				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"../../externals/macosx/fftw-3.3.3",


### PR DESCRIPTION
Currently in Integra Live 2 we're having to run install_name_tool on the final framework to set the runtime linker path to the framework embed inside the application. This change should make it a bit easier for the frameworks users to embed the framework within an application bundle