### PR TITLE
Use @rpath for INSTALL_PATH

### DIFF
--- a/libIntegra/xcode/Integra/Integra.xcodeproj/project.pbxproj
+++ b/libIntegra/xcode/Integra/Integra.xcodeproj/project.pbxproj
@@ -1274,6 +1274,7 @@
 					../../externals/boost,
 				);
 				INFOPLIST_FILE = "Integra/Integra-Info.plist";
+				INSTALL_PATH = "@rpath";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
@@ -1334,6 +1335,7 @@
 					../../externals/boost,
 				);
 				INFOPLIST_FILE = "Integra/Integra-Info.plist";
+				INSTALL_PATH = "@rpath";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (


### PR DESCRIPTION
This lets the linking app to define the framework location. This wasn't included in the previous PR and so there was still a bit more work than there should have been to link successfully. Setting `LD_RUNPATH_SEARCH_PATHS` is all that needs to be done now to set the framework directory for runtime linking.